### PR TITLE
Tiny2350: Add PPP support for LTE module.

### DIFF
--- a/boards/pimoroni_tiny2350/manifest.py
+++ b/boards/pimoroni_tiny2350/manifest.py
@@ -1,3 +1,5 @@
+require("bundle-networking")
+
 include("$(PORT_DIR)/boards/manifest.py")
 
 include("../manifest_pico2.py")

--- a/boards/pimoroni_tiny2350/mpconfigboard.cmake
+++ b/boards/pimoroni_tiny2350/mpconfigboard.cmake
@@ -7,4 +7,8 @@ set(MICROPY_FROZEN_MANIFEST ${MICROPY_BOARD_DIR}/manifest.py)
 
 set(MICROPY_C_HEAP_SIZE 4096)
 
+# Links micropy_lib_lwip and sets MICROPY_PY_LWIP = 1
+# Picked up and expanded upon in mpconfigboard.h
+set(MICROPY_PY_LWIP ON)
+
 include(${CMAKE_CURRENT_LIST_DIR}/../common.cmake)

--- a/boards/pimoroni_tiny2350/mpconfigboard.h
+++ b/boards/pimoroni_tiny2350/mpconfigboard.h
@@ -1,6 +1,13 @@
 // Board and hardware specific configuration
-#define MICROPY_HW_BOARD_NAME                   "Pimoroni Tiny 2350"
+#define MICROPY_HW_BOARD_NAME                   "Pimoroni Tiny 2350 (PPP)"
 #define MICROPY_HW_FLASH_STORAGE_BYTES          (PICO_FLASH_SIZE_BYTES - (2 * 1024 * 1024))
+
+// Set up networking.
+#define MICROPY_PY_NETWORK_HOSTNAME_DEFAULT     "PPP2"
+
+// Enable Networking & PPP
+#define MICROPY_PY_NETWORK                      (1)
+#define MICROPY_PY_NETWORK_PPP_LWIP             (1)
 
 // I2C0 (non-default)
 #define MICROPY_HW_I2C0_SCL  (4)


### PR DESCRIPTION
👉  https://github.com/pimoroni/pimoroni-pico-rp2350/actions/runs/19804063924/artifacts/4718277979 👈 

This PR adds LTE compatibility to Tiny2350.

This is extremely untested, but Tiny2350 has a bunch of pins with UART support so, in theory, it should work.